### PR TITLE
Bg fixing post order

### DIFF
--- a/controllers/order/addOrder.js
+++ b/controllers/order/addOrder.js
@@ -2,8 +2,11 @@ const Order = require('../../models/orders');
 const Store = require('../../models/store');
 
 async function addOrder(req, res) {
+	const storeId = req.params.storeID;
+	console.log(storeId);
 	try {
-		const store = await Store.findOne({ seller: req.params.sellerId }).exec();
+		const store = await Store.findOne({ _id: storeId });
+		console.log(store);
 		if (!store) {
 			return res.status(404).json({ message: 'There is no store associated with this account' });
 		}
@@ -11,6 +14,7 @@ async function addOrder(req, res) {
 		order.storeId = store._id;
 		const newOrder = new Order(order);
 		const result = await newOrder.save();
+		console.log(result);
 		return res.json(result);
 	} catch (err) {
 		res.json(err.message);

--- a/controllers/order/addOrder.js
+++ b/controllers/order/addOrder.js
@@ -2,7 +2,7 @@ const Order = require('../../models/orders');
 const Store = require('../../models/store');
 
 async function addOrder(req, res) {
-	const storeId = req.params.storeID;
+	const storeId = req.params.storeId;
 	console.log(storeId);
 	try {
 		const store = await Store.findOne({ _id: storeId });
@@ -11,7 +11,7 @@ async function addOrder(req, res) {
 			return res.status(404).json({ message: 'There is no store associated with this account' });
 		}
 		const order = req.body;
-		order.storeId = store._id;
+		order.storeId = storeId;
 		const newOrder = new Order(order);
 		const result = await newOrder.save();
 		console.log(result);

--- a/routes/orderRouter.js
+++ b/routes/orderRouter.js
@@ -11,7 +11,7 @@ router.get('/:store_id/order', getOrders);
 
 router.get('/order/:order_id', getOneOrder);
 
-router.post('/:storeID/order', addOrder);
+router.post('/:storeId/order', addOrder);
 
 router.put('/order/:order_id', authenticate, editOrder);
 

--- a/routes/orderRouter.js
+++ b/routes/orderRouter.js
@@ -11,7 +11,7 @@ router.get('/:store_id/order', getOrders);
 
 router.get('/order/:order_id', getOneOrder);
 
-router.post('/:storeId/order', addOrder);
+router.post('/:storeID/order', addOrder);
 
 router.put('/order/:order_id', authenticate, editOrder);
 


### PR DESCRIPTION
## Description
Add order had an auth on it that was making it so that you can't add order with token. Removed it and made so that now orders can be associated with stores based on storeId. 

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue
